### PR TITLE
push images from arm based machines

### DIFF
--- a/build_scripts/push-client-image.sh
+++ b/build_scripts/push-client-image.sh
@@ -10,7 +10,7 @@ project_id=my-project-1499979282244
 image_name="gcr.io/${project_id}/omnipaxos_client"
 
 println_green "Building client docker image with name '${image_name}'"
-docker build -t "${image_name}" -f  ../client.dockerfile ../
+docker build --platform linux/amd64 -t "${image_name}" -f  ../client.dockerfile ../
 
 println_green "Pushing '${image_name}' to registry"
 docker push "${image_name}"

--- a/build_scripts/push-server-image.sh
+++ b/build_scripts/push-server-image.sh
@@ -10,7 +10,7 @@ project_id=my-project-1499979282244
 image_name="gcr.io/${project_id}/omnipaxos_server"
 
 println_green "Building server docker image with name '${image_name}'"
-docker build -t "${image_name}" -f  ../server.dockerfile ../
+docker build --platform linux/amd64 -t "${image_name}" -f  ../server.dockerfile ../
 
 println_green "Pushing '${image_name}' to registry"
 docker push "${image_name}"


### PR DESCRIPTION
When building an image on an ARM-based machine and pushing it to the artifact registry, it does not work with Cloud Run. 
Fixed by building the container with the --platform linux/amd64 flag before deploying the image to Cloud Run as mentioned in this thread https://stackoverflow.com/a/77998810